### PR TITLE
Mask image nasuu0612 ver2

### DIFF
--- a/draw_app/lib/main.dart
+++ b/draw_app/lib/main.dart
@@ -9,6 +9,7 @@ import 'page4_condition.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:device_preview/device_preview.dart';
+import 'dart:typed_data';
 import 'dart:io';
 
 /*
@@ -35,7 +36,16 @@ class App extends StatelessWidget {
       GoRoute(path: '/a', builder: (context, state) => const PageA()),
       //GoRoute(path: '/b', builder: (context, state) => const PageB()),
       GoRoute(path: '/b', builder: (context, state) => const Page2Draw()),
-      GoRoute(path: '/b1', builder: (context, state) => const Page2Select()),
+      GoRoute(
+        path: '/b1',
+        builder: (context, state) {
+          final args = state.extra as Map<String, dynamic>;
+          return Page2Select(
+            underImageFile: args['underImageFile'] as File,
+            upperImageBytes: args['upperImageBytes'] as Uint8List,
+          );
+        },
+      ),
       GoRoute(
         path: '/b2',
         builder: (context, state) {

--- a/draw_app/lib/main.dart
+++ b/draw_app/lib/main.dart
@@ -40,10 +40,7 @@ class App extends StatelessWidget {
         path: '/b1',
         builder: (context, state) {
           final args = state.extra as Map<String, dynamic>;
-          return Page2Select(
-            underImageFile: args['underImageFile'] as File,
-            upperImageBytes: args['upperImageBytes'] as Uint8List,
-          );
+          return Page2Select(underImageFile: args['underImageFile'] as File);
         },
       ),
       GoRoute(

--- a/draw_app/lib/page2-1_select.dart
+++ b/draw_app/lib/page2-1_select.dart
@@ -1,69 +1,229 @@
-import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'dart:io';
 import 'dart:typed_data';
-//
-// 画面 b1
-//
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:go_router/go_router.dart';
+import 'package:image/image.dart' as img;
 
-class Page2Select extends StatelessWidget {
-  const Page2Select({super.key});
+// b1
+
+class Page2Select extends StatefulWidget {
+  final File underImageFile; // 撮影された下の画像（写真）
+
+  const Page2Select({Key? key, required this.underImageFile}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    // extraで渡されたデータを受け取る
-    final extra = GoRouterState.of(context).extra as Map<String, dynamic>?;
-    final File? _imageFile = extra?['underImageFile'];
-    final Uint8List? _upperImageBytes = extra?['upperImageBytes'];
+  State<Page2Select> createState() => _Page2SelectState();
+}
 
-    // 完了ボタンを押したときの処理
-    void _completeAndProceed() {
-      if (_imageFile != null && _upperImageBytes != null) {
-        context.push(
-          '/b2',
-          extra: {
-            'underImageFile': _imageFile,
-            'upperImageBytes': _upperImageBytes,
-          },
-        );
-      } else {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('写真またはマスク画像がありません')));
+class _Page2SelectState extends State<Page2Select> {
+  final int maskCount = 30; // マスク画像の枚数（mask_0.png〜mask_29.png）
+  late List<String> maskAssetPaths;
+
+  List<img.Image?> decodedMasks = []; // 各マスク画像のデコード結果を保持
+  img.Image? decodedLineImage; // 線画画像（line.png）
+
+  int? selectedRegionIndex; // ユーザーが選択したマスク番号
+  Uint8List? previewImageBytes; // UI上に表示するプレビュー画像
+  bool isMerging = false; // 合成処理中かどうか
+
+  @override
+  void initState() {
+    super.initState();
+
+    // マスク画像のパスを生成
+    maskAssetPaths = List.generate(
+      maskCount,
+      (i) => 'assets/PaintApp_illust/mask_$i.png',
+    );
+
+    // マスクと線画画像を読み込む
+    _loadImages();
+  }
+
+  // マスク画像と線画画像(line.png)を読み込んで保持する
+  Future<void> _loadImages() async {
+    decodedMasks.clear();
+
+    // 各マスク画像を読み込んで decodePng して配列に追加
+    for (var path in maskAssetPaths) {
+      final data = await rootBundle.load(path);
+      final bytes = data.buffer.asUint8List();
+      final decoded = img.decodePng(bytes);
+      decodedMasks.add(decoded);
+    }
+
+    // 線画画像(line.png)を読み込んで保持
+    final lineData = await rootBundle.load('assets/PaintApp_illust/line.png');
+    final lineBytes = lineData.buffer.asUint8List();
+    decodedLineImage = img.decodePng(lineBytes);
+
+    // プレビュー用画像を初期表示に設定
+    if (decodedLineImage != null) {
+      previewImageBytes = Uint8List.fromList(img.encodePng(decodedLineImage!));
+    }
+
+    setState(() {});
+  }
+
+  // タップされた座標がどのマスクに含まれるか判定
+  int? detectTappedRegion(int x, int y) {
+    for (int i = 0; i < decodedMasks.length; i++) {
+      final mask = decodedMasks[i];
+      if (mask == null) continue;
+      if (x < 0 || x >= mask.width || y < 0 || y >= mask.height) continue;
+
+      final pixel = mask.getPixel(x, y);
+      if (pixel.a > 0) return i; // 透明でなければ領域と判定
+    }
+    return null;
+  }
+
+  // 指定された領域だけを除いて、他のマスクをすべて線画に合成する
+  Future<Uint8List?> mergeLayersExcludingSelected(int excludeIndex) async {
+    if (decodedLineImage == null) return null;
+
+    final output = img.Image.from(decodedLineImage!);
+
+    for (int i = 0; i < decodedMasks.length; i++) {
+      if (i == excludeIndex) continue; // 除外対象(選ばれた領域)はスキップ
+      final mask = decodedMasks[i];
+      if (mask != null) {
+        img.compositeImage(output, mask);
       }
     }
 
-    final appBar = AppBar(
-      backgroundColor: Colors.green,
-      title: const Text('Select'),
-    );
+    return Uint8List.fromList(img.encodePng(output));
+  }
 
-    final completeButton = ElevatedButton(
-      onPressed: _completeAndProceed,
-      style: ElevatedButton.styleFrom(backgroundColor: Colors.blue),
-      child: const Text('完了'),
-    );
+  // 選択されたマスク領域を赤色でハイライト表示する
+  Uint8List? applyHighlight(int index) {
+    if (decodedLineImage == null || index < 0 || index >= decodedMasks.length)
+      return null;
 
+    final base = img.Image.from(decodedLineImage!);
+    final mask = decodedMasks[index];
+    if (mask == null) return null;
+
+    for (int y = 0; y < mask.height; y++) {
+      for (int x = 0; x < mask.width; x++) {
+        final pixel = mask.getPixel(x, y);
+        if (pixel.a > 0) {
+          base.setPixelRgba(x, y, 255, 0, 0, 128); // 赤の半透明で重ねる
+        }
+      }
+    }
+
+    return Uint8List.fromList(img.encodePng(base));
+  }
+
+  // タップ座標を画像座標に変換
+  Offset? convertToImageCoordinates(
+    TapDownDetails details,
+    BoxConstraints constraints,
+    img.Image baseImage,
+  ) {
+    final localPos = details.localPosition;
+    final scaleX = baseImage.width / constraints.maxWidth;
+    final scaleY = baseImage.height / constraints.maxHeight;
+    final x = (localPos.dx * scaleX).toInt();
+    final y = (localPos.dy * scaleY).toInt();
+    return Offset(x.toDouble(), y.toDouble());
+  }
+
+  // タップされたときの処理
+  void onTapDown(TapDownDetails details, BoxConstraints constraints) {
+    if (decodedLineImage == null) return;
+
+    final pos = convertToImageCoordinates(
+      details,
+      constraints,
+      decodedLineImage!,
+    );
+    if (pos == null) return;
+
+    final tappedIndex = detectTappedRegion(pos.dx.toInt(), pos.dy.toInt());
+    if (tappedIndex == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('領域が見つかりません')));
+      return;
+    }
+
+    final highlighted = applyHighlight(tappedIndex);
+    if (highlighted == null) return;
+
+    setState(() {
+      selectedRegionIndex = tappedIndex;
+      previewImageBytes = highlighted;
+    });
+  }
+
+  // 完了ボタンが押されたときの処理（合成して次の画面へ）
+  Future<void> onCompletePressed() async {
+    if (selectedRegionIndex == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('領域が選択されていません')));
+      return;
+    }
+
+    setState(() => isMerging = true);
+
+    final merged = await mergeLayersExcludingSelected(selectedRegionIndex!);
+
+    setState(() => isMerging = false);
+
+    if (merged == null) return;
+
+    // 次の画面（Page2Edit）へ遷移し、画像を渡す
+    context.push(
+      '/b2',
+      extra: {
+        'underImageFile': widget.underImageFile,
+        'upperImageBytes': merged,
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
-      appBar: appBar,
-      body: Stack(
-        children: [
-          if (_upperImageBytes != null)
-            Center(child: Image.memory(_upperImageBytes, fit: BoxFit.contain))
-          else
-            const Center(child: Text('マスク画像がありません')),
-          Align(
-            alignment: Alignment.bottomRight,
-            child: Padding(
-              padding: const EdgeInsets.all(30.0),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [completeButton],
-              ),
+      appBar: AppBar(title: const Text('Select')),
+      body: decodedLineImage == null
+          ? const Center(child: CircularProgressIndicator()) // 読み込み中
+          : LayoutBuilder(
+              builder: (context, constraints) {
+                return GestureDetector(
+                  onTapDown: (details) => onTapDown(details, constraints),
+                  child: Stack(
+                    children: [
+                      Center(
+                        child: previewImageBytes != null
+                            ? Image.memory(
+                                previewImageBytes!,
+                                fit: BoxFit.contain,
+                                cacheWidth: 512,
+                              )
+                            : Container(),
+                      ),
+                      Align(
+                        alignment: Alignment.bottomRight,
+                        child: Padding(
+                          padding: const EdgeInsets.all(30),
+                          child: isMerging
+                              ? const CircularProgressIndicator()
+                              : ElevatedButton(
+                                  onPressed: onCompletePressed,
+                                  child: const Text('完了'),
+                                ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
             ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/draw_app/lib/page2_draw.dart
+++ b/draw_app/lib/page2_draw.dart
@@ -18,20 +18,10 @@ class _Page2DrawState extends State<Page2Draw> {
   final CameraHandler _cameraHandler = CameraHandler();
   XFile? _imageFile; //キャプチャした画像を保存する変数
   bool _showCameraPreview = false;
-  Uint8List? _upperImageBytes; // ダミーで読み込むマスク画像
 
   @override
   void initState() {
     super.initState();
-    _loadDummyMask();
-  }
-
-  Future<void> _loadDummyMask() async {
-    // assets/images/mask.png を読み込む
-    final bytes = await rootBundle.load('assets/images/mask.png');
-    setState(() {
-      _upperImageBytes = bytes.buffer.asUint8List();
-    });
   }
 
   @override
@@ -42,15 +32,9 @@ class _Page2DrawState extends State<Page2Draw> {
 
   //完了ボタンのアクション(元のファイルのpushメソッドの部分)
   void _completeAndProceed() {
-    if (_imageFile != null && _upperImageBytes != null) {
+    if (_imageFile != null) {
       // カメラ画像（downer）とマスク画像（upper）をpage2-1_selectに渡す
-      context.push(
-        '/b1',
-        extra: {
-          'underImageFile': File(_imageFile!.path),
-          'upperImageBytes': _upperImageBytes,
-        },
-      );
+      context.push('/b1', extra: {'underImageFile': File(_imageFile!.path)});
     } else {
       ScaffoldMessenger.of(
         context,
@@ -217,28 +201,6 @@ class _Page2DrawState extends State<Page2Draw> {
       body: Stack(
         children: [
           mainContent, //カメラプレビューor画像or初期メッセージ
-          if (_upperImageBytes != null)
-            Positioned(
-              top: 30,
-              left: 30,
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.green, width: 2),
-                  borderRadius: BorderRadius.circular(8),
-                  color: Colors.white,
-                ),
-                child: Column(
-                  children: [
-                    const Text('マスク画像（ダミー）プレビュー'),
-                    SizedBox(
-                      width: 80,
-                      height: 80,
-                      child: Image.memory(_upperImageBytes!),
-                    ),
-                  ],
-                ),
-              ),
-            ),
           Align(
             alignment: Alignment.topCenter,
             child: Padding(


### PR DESCRIPTION
塗りたい領域を選択し、完了ボタンを押すとその領域の部分だけ透明になった画像（穴あきの画像）が編集画面にわたるようにしました。

## 流れ
①読み込み(線画と30枚のマスク画像をロード)
②線画画像（現在の（途中まで塗ってある）塗り絵の画像に変更予定）を表示
③ユーザーにタップされた部分を座標取ってマスク判定し、赤くハイライト
④完了が押されたらハイライトした領域以外を合成して次画面へ渡す
（ここもマスク全部くっつける方法ではなく、くりぬく方法に改善予定）

##
（ダミー画像は削除しました）
（処理がまだ重いです）
